### PR TITLE
Fix prerequisites.inc.php

### DIFF
--- a/files/php/prerequisites.inc.php
+++ b/files/php/prerequisites.inc.php
@@ -1,1 +1,1 @@
-
+<?php /* Leaving this without php tag outputs line characters to response */ ?>


### PR DESCRIPTION
I noticed that images are downloaded but not displayed. This file is the culprit. It outputs line character when included. It makes image header not recognizable by browser. Adding php tag fixed it.