### PR TITLE
Fixes towards PHP8 and type-hinting

### DIFF
--- a/files/php/functions.inc.php
+++ b/files/php/functions.inc.php
@@ -1,18 +1,18 @@
 <?php
-function show_report($data)
+function show_report(array $data)
 {
     require_once "./files/php/index.inc.php";
     exit(0);
 }
 
-function add_cookie($name, $value, $expires = 0)
+function add_cookie(string $name, $value, $expires = 0)
 {
     return rawurlencode(rawurlencode($name)) . '=' . rawurlencode(rawurlencode($value)) . (empty($expires) ? '' : '; expires=' . gmdate('D, d-M-Y H:i:s \G\M\T', $expires)) . '; path=/; domain=.' . $GLOBALS['_http_host'];
 }
 
-function set_post_vars($array, $parent_key = null)
+function set_post_vars(array $array, $parent_key = null)
 {
-    $temp = array();
+    $temp = [];
 
     foreach ($array as $key => $value) {
         $key = isset($parent_key) ? sprintf('%s[%s]', $parent_key, urlencode($key)) : urlencode($key);
@@ -26,9 +26,9 @@ function set_post_vars($array, $parent_key = null)
     return $temp;
 }
 
-function set_post_files($array, $parent_key = null)
+function set_post_files(array $array, $parent_key = null)
 {
-    $temp = array();
+    $temp = [];
 
     foreach ($array as $key => $value) {
         $key = isset($parent_key) ? sprintf('%s[%s]', $parent_key, urlencode($key)) : urlencode($key);
@@ -42,7 +42,7 @@ function set_post_files($array, $parent_key = null)
     return $temp;
 }
 
-function url_parse($url, &$container)
+function url_parse(string $url, &$container)
 {
     $temp = @parse_url($url);
 
@@ -57,7 +57,7 @@ function url_parse($url, &$container)
         }
 
         $temp['path'] = isset($temp['path']) ? $temp['path'] : '/';
-        $path         = array();
+        $path         = [];
         $temp['path'] = explode('/', $temp['path']);
 
         foreach ($temp['path'] as $dir) {
@@ -82,7 +82,7 @@ function url_parse($url, &$container)
     return false;
 }
 
-function complete_url($url, $proxify = true)
+function complete_url(string $url, bool $proxify = true)
 {
     $url = html_entity_decode(trim($url));
 
@@ -128,7 +128,7 @@ function complete_url($url, $proxify = true)
     return $proxify ? "{$GLOBALS['_script_url']}?{$GLOBALS['_config']['url_var_name']}=" . encode_url($url) . $fragment : $url;
 }
 
-function proxify_inline_css($css)
+function proxify_inline_css(string $css)
 {
     preg_match_all('#url\s*\(\s*(.+?(?=\)[f;,}!\s*]))\)#i', $css, $matches, PREG_SET_ORDER);
 
@@ -139,7 +139,7 @@ function proxify_inline_css($css)
     return $css;
 }
 
-function proxify_css($css)
+function proxify_css(string $css)
 {
     $css = proxify_inline_css($css);
 
@@ -160,7 +160,7 @@ function proxify_css($css)
     return $css;
 }
 
-function proxify_css_url($url)
+function proxify_css_url(string $url)
 {
     $url   = trim($url);
     $delim = strpos($url, '"') === 0 ? '"' : (strpos($url, "'") === 0 ? "'" : '');
@@ -182,7 +182,7 @@ function proxify_css_url($url)
     return $delim . preg_replace('#([\(\),\s\'"\\\])#', '\\$1', complete_url(trim(preg_replace('#\\\(.)#', '$1', $url)))) . $delim;
 }
 
-function encode_url($url)
+function encode_url(string $url)
 {
     global $_flags;
 
@@ -195,7 +195,7 @@ function encode_url($url)
     return rawurlencode($url);
 }
 
-function decode_url($url)
+function decode_url(string $url)
 {
     global $_flags;
     $url = rawurldecode($url);
@@ -206,5 +206,5 @@ function decode_url($url)
         $url = base64_decode($url);
     }
 
-    return str_replace(array('&amp;', '&#38;'), '&', $url);
+    return str_replace(['&amp;', '&#38;'], '&', $url);
 }

--- a/files/php/functions.inc.php
+++ b/files/php/functions.inc.php
@@ -64,7 +64,7 @@ function url_parse(string $url, &$container)
             if ($dir === '..') {
                 array_pop($path);
             } else if ($dir !== '.') {
-                for ($dir = rawurldecode($dir), $new_dir = '', $i = 0, $count_i = strlen($dir); $i < $count_i; $new_dir .= strspn($dir{$i}, 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789$-_.+!*\'(),?:@&;=') ? $dir{$i} : rawurlencode($dir{$i}), ++$i);
+                for ($dir = rawurldecode($dir), $new_dir = '', $i = 0, $count_i = strlen($dir); $i < $count_i; $new_dir .= strspn($dir[$i], 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789$-_.+!*\'(),?:@&;=') ? $dir[$i] : rawurlencode($dir[$i]), ++$i);
                 $path[] = $new_dir;
             }
         }

--- a/files/php/functions.inc.php
+++ b/files/php/functions.inc.php
@@ -1,16 +1,16 @@
 <?php
-function show_report(array $data)
+function show_report(array $data): void
 {
     require_once "./files/php/index.inc.php";
     exit(0);
 }
 
-function add_cookie(string $name, $value, $expires = 0)
+function add_cookie(string $name, mixed $value, int $expires = 0): string
 {
     return rawurlencode(rawurlencode($name)) . '=' . rawurlencode(rawurlencode($value)) . (empty($expires) ? '' : '; expires=' . gmdate('D, d-M-Y H:i:s \G\M\T', $expires)) . '; path=/; domain=.' . $GLOBALS['_http_host'];
 }
 
-function set_post_vars(array $array, $parent_key = null)
+function set_post_vars(array $array, string $parent_key = null): array
 {
     $temp = [];
 
@@ -26,7 +26,7 @@ function set_post_vars(array $array, $parent_key = null)
     return $temp;
 }
 
-function set_post_files(array $array, $parent_key = null)
+function set_post_files(array $array, string $parent_key = null): array
 {
     $temp = [];
 
@@ -42,7 +42,7 @@ function set_post_files(array $array, $parent_key = null)
     return $temp;
 }
 
-function url_parse(string $url, &$container)
+function url_parse(string $url, array &$container): bool
 {
     $temp = @parse_url($url);
 
@@ -82,7 +82,7 @@ function url_parse(string $url, &$container)
     return false;
 }
 
-function complete_url(string $url, bool $proxify = true)
+function complete_url(string $url, bool $proxify = true): string
 {
     $url = html_entity_decode(trim($url));
 
@@ -128,7 +128,7 @@ function complete_url(string $url, bool $proxify = true)
     return $proxify ? "{$GLOBALS['_script_url']}?{$GLOBALS['_config']['url_var_name']}=" . encode_url($url) . $fragment : $url;
 }
 
-function proxify_inline_css(string $css)
+function proxify_inline_css(string $css): string
 {
     preg_match_all('#url\s*\(\s*(.+?(?=\)[f;,}!\s*]))\)#i', $css, $matches, PREG_SET_ORDER);
 
@@ -139,7 +139,7 @@ function proxify_inline_css(string $css)
     return $css;
 }
 
-function proxify_css(string $css)
+function proxify_css(string $css): string
 {
     $css = proxify_inline_css($css);
 
@@ -160,7 +160,7 @@ function proxify_css(string $css)
     return $css;
 }
 
-function proxify_css_url(string $url)
+function proxify_css_url(string $url): string
 {
     $url   = trim($url);
     $delim = strpos($url, '"') === 0 ? '"' : (strpos($url, "'") === 0 ? "'" : '');
@@ -182,7 +182,7 @@ function proxify_css_url(string $url)
     return $delim . preg_replace('#([\(\),\s\'"\\\])#', '\\$1', complete_url(trim(preg_replace('#\\\(.)#', '$1', $url)))) . $delim;
 }
 
-function encode_url(string $url)
+function encode_url(string $url): string
 {
     global $_flags;
 
@@ -195,7 +195,7 @@ function encode_url(string $url)
     return rawurlencode($url);
 }
 
-function decode_url(string $url)
+function decode_url(string $url): string
 {
     global $_flags;
     $url = rawurldecode($url);

--- a/index.php
+++ b/index.php
@@ -90,7 +90,7 @@ $_system            =
                         'ssl'          => extension_loaded('openssl') && version_compare(PHP_VERSION, '4.3.0', '>='),
                         'uploads'      => ini_get('file_uploads'),
                         'gzip'         => extension_loaded('zlib') && !ini_get('zlib.output_compression'),
-                        'stripslashes' => get_magic_quotes_gpc()
+                        'stripslashes' => true,
                     ];
 $_proxify           =
                     [

--- a/index.php
+++ b/index.php
@@ -144,7 +144,7 @@ if(!isset($pos) || $pos == ""){ // empty means old method
 $_bindip           = 'default';
 
 // Functions declaration
-require_once("./files/php/functions.inc.php");
+require_once "./files/php/functions.inc.php";
 
 //
 // SET FLAGS
@@ -282,7 +282,7 @@ else
 	$chars = str_split($_url_parts['host']);
 	foreach($chars as $char){
 		if(ord($char)>122){
-			require_once("./files/php/idna.class.php");
+			require_once "./files/php/idna.class.php";
 			$php_idna = new php_idna();
 			$_url_parts['host'] = $php_idna->encode($_url_parts['host']);
 			break;
@@ -1083,8 +1083,8 @@ else
         }
     }
 
-    include('./files/php/misc.php');
-    require_once("./files/php/misc.override.php");
+    include './files/php/misc.php';
+    require_once "./files/php/misc.override.php";
     if ($_flags['include_form'] && !isset($_GET['nf']))
     {
         $_url_form      = '<div style="width:100%;margin:0;text-align:center;border-bottom:1px solid #725554;color:#000000;background-color:#F2FDF3;font-size:12px;font-weight:bold;font-family:Bitstream Vera Sans,arial,sans-serif;padding:4px;">'

--- a/index.php
+++ b/index.php
@@ -21,8 +21,8 @@ error_reporting(0);
 // CONFIGURABLE OPTIONS
 //
 
-$_config            = array
-                    (
+$_config            =
+                    [
                         'url_var_name'             => '_proxurl',
                         'flags_var_name'           => '_proxfl',
                         'get_form_name'            => '_proxgfn',
@@ -31,10 +31,10 @@ $_config            = array
                         'max_file_size'            => -1,
                         'allow_hotlinking'         => 0,
                         'upon_hotlink'             => 1,
-                        'compress_output'          => 0
-                    );
-$_flags             = array
-                    (
+                        'compress_output'          => 0,
+                    ];
+$_flags             =
+                    [
                         'include_form'    => 0,
                         'remove_scripts'  => 1,
                         'accept_cookies'  => 1,
@@ -44,10 +44,10 @@ $_flags             = array
                         'base64_encode'   => 1,
                         'strip_meta'      => 0,
                         'strip_title'     => 1,
-                        'session_cookies' => 1
-                    );
-$_frozen_flags      = array
-                    (
+                        'session_cookies' => 1,
+                    ];
+$_frozen_flags      =
+                    [
                         'include_form'    => 0,
                         'remove_scripts'  => 0,
                         'accept_cookies'  => 0,
@@ -57,42 +57,48 @@ $_frozen_flags      = array
                         'base64_encode'   => 0,
                         'strip_meta'      => 0,
                         'strip_title'     => 0,
-                        'session_cookies' => 0
-                    );
-$_labels            = array
-                    (
-                        'include_form'    => array('Include Form', 'Include mini URL-form on every page'),
-                        'remove_scripts'  => array('Remove Scripts', 'Remove client-side scripting (i.e JavaScript)'),
-                        'accept_cookies'  => array('Accept Cookies', 'Allow cookies to be stored'),
-                        'show_images'     => array('Show Images', 'Show images on browsed pages'),
-                        'show_referer'    => array('Show Referer', 'Show actual referring Website'),
-                        'rotate13'        => array('Rotate13', 'Use ROT13 encoding on the address'),
-                        'base64_encode'   => array('Base64', 'Use base64 encoding on the address'),
-                        'strip_meta'      => array('Strip Meta', 'Strip meta information tags from pages'),
-                        'strip_title'     => array('Strip Title', 'Strip page title'),
-                        'session_cookies' => array('Session Cookies', 'Store cookies for this session only')
-                    );
+                        'session_cookies' => 0,
+                    ];
+$_labels            =
+                    [
+                        'include_form'    => ['Include Form', 'Include mini URL-form on every page'],
+                        'remove_scripts'  => ['Remove Scripts', 'Remove client-side scripting (i.e JavaScript)'],
+                        'accept_cookies'  => ['Accept Cookies', 'Allow cookies to be stored'],
+                        'show_images'     => ['Show Images', 'Show images on browsed pages'],
+                        'show_referer'    => ['Show Referer', 'Show actual referring Website'],
+                        'rotate13'        => ['Rotate13', 'Use ROT13 encoding on the address'],
+                        'base64_encode'   => ['Base64', 'Use base64 encoding on the address'],
+                        'strip_meta'      => ['Strip Meta', 'Strip meta information tags from pages'],
+                        'strip_title'     => ['Strip Title', 'Strip page title'],
+                        'session_cookies' => ['Session Cookies', 'Store cookies for this session only'],
+                    ];
 
-$_hosts             = array
-                    (
-                        '#^127\.|192\.168\.|10\.|172\.(1[6-9]|2[0-9]|3[01])\.|localhost#i'
-                    );
-$_hotlink_domains   = array();
-$_insert            = array();
+$_hosts             =
+                    [
+                        '#^127\.|192\.168\.|10\.|172\.(1[6-9]|2[0-9]|3[01])\.|localhost#i',
+                    ];
+$_hotlink_domains   = [];
+$_insert            = [];
 
 //
 // END CONFIGURABLE OPTIONS. The ride for you ends here. Close the file.
 //
 
 $_iflags            = '';
-$_system            = array
-                    (
+$_system            =
+                    [
                         'ssl'          => extension_loaded('openssl') && version_compare(PHP_VERSION, '4.3.0', '>='),
                         'uploads'      => ini_get('file_uploads'),
                         'gzip'         => extension_loaded('zlib') && !ini_get('zlib.output_compression'),
                         'stripslashes' => get_magic_quotes_gpc()
-                    );
-$_proxify           = array('text/html' => 1, 'application/xml+xhtml' => 1, 'application/xhtml+xml' => 1, 'text/css' => 1);
+                    ];
+$_proxify           =
+                    [
+                        'text/html'             => 1,
+                        'application/xml+xhtml' => 1,
+                        'application/xhtml+xml' => 1,
+                        'text/css'              => 1,
+                    ];
 $_version           = 'v1.1.1';
 $_http_host         = isset($_SERVER['HTTP_HOST']) ? $_SERVER['HTTP_HOST'] : (isset($_SERVER['SERVER_NAME']) ? $_SERVER['SERVER_NAME'] : 'localhost');
 // https://stackoverflow.com/questions/4504831/serverhttp-host-contains-port-number-too
@@ -103,26 +109,26 @@ if ($pos) {
 $_script_url        = 'http' . ((isset($_ENV['HTTPS']) && $_ENV['HTTPS'] == 'on') || $_SERVER['SERVER_PORT'] == 443 ? 's' : '') . '://' . $_http_host . ($_SERVER['SERVER_PORT'] != 80 && $_SERVER['SERVER_PORT'] != 443 ? ':' . $_SERVER['SERVER_PORT'] : '') . $_SERVER['PHP_SELF'];
 $_script_base       = substr($_script_url, 0, strrpos($_script_url, '/')+1);
 $_url               = '';
-$_url_parts         = array();
-$_base              = array();
+$_url_parts         = [];
+$_base              = [];
 $_socket            = null;
 $_request_method    = $_SERVER['REQUEST_METHOD'];
 $_request_headers   = '';
 $_cookie            = '';
 $_post_body         = '';
-$_response_headers  = array();
-$_response_keys     = array();
+$_response_headers  = [];
+$_response_keys     = [];
 $_http_version      = '';
 $_response_code     = 0;
 $_content_type      = 'text/html';
 $_content_length    = false;
 $_content_disp      = '';
-$_set_cookie        = array();
+$_set_cookie        = [];
 $_retry             = false;
 $_quit              = false;
 $_basic_auth_header = '';
 $_basic_auth_realm  = '';
-$_auth_creds        = array();
+$_auth_creds        = [];
 $_response_body     = '';
 $pos = $_COOKIE['userAgent'];
 if(!isset($pos) || $pos == ""){ // empty means old method
@@ -236,7 +242,7 @@ else if (isset($_GET[$_config['url_var_name']]))
 }
 else
 {
-    show_report(array('which' => 'index', 'category' => 'entry_form'));
+    show_report(['which' => 'index', 'category' => 'entry_form']);
 }
 
 if (isset($_GET[$_config['url_var_name']], $_POST[$_config['basic_auth_var_name']], $_POST['username'], $_POST['password']))
@@ -265,14 +271,14 @@ if (url_parse($_url, $_url_parts))
         {
             if (preg_match($host, $_url_parts['host']))
             {
-                show_report(array('which' => 'index', 'category' => 'error', 'group' => 'url', 'type' => 'external', 'error' => 1));
+                show_report(['which' => 'index', 'category' => 'error', 'group' => 'url', 'type' => 'external', 'error' => 1]);
             }
         }
     }
 }
 else
 {
-    show_report(array('which' => 'index', 'category' => 'error', 'group' => 'url', 'type' => 'external', 'error' => 2));
+    show_report(['which' => 'index', 'category' => 'error', 'group' => 'url', 'type' => 'external', 'error' => 2]);
 }
 
 
@@ -313,7 +319,7 @@ if (!$_config['allow_hotlinking'] && isset($_SERVER['HTTP_REFERER']))
         switch ($_config['upon_hotlink'])
         {
             case 1:
-                show_report(array('which' => 'index', 'category' => 'error', 'group' => 'resource', 'type' => 'hotlinking'));
+                show_report(['which' => 'index', 'category' => 'error', 'group' => 'resource', 'type' => 'hotlinking']);
                 break;
             case 2:
                 header('HTTP/1.0 404 Not Found');
@@ -333,7 +339,7 @@ do
 {
    $context = stream_context_create();
    if ( $_bindip != 'default') {
-      $opts = array('socket' => array('bindto' => $_bindip));
+      $opts = ['socket' => ['bindto' => $_bindip]];
       $context = stream_context_create($opts);
    }
 
@@ -342,7 +348,7 @@ do
 
     if ($_socket === false)
     {
-        show_report(array('which' => 'index', 'category' => 'error', 'group' => 'url', 'type' => 'internal', 'error' => $err_no));
+        show_report(['which' => 'index', 'category' => 'error', 'group' => 'url', 'type' => 'internal', 'error' => $err_no]);
     }
 
     //
@@ -380,7 +386,7 @@ do
     if (!empty($_COOKIE))
     {
         $_cookie  = '';
-        $_auth_creds    = array();
+        $_auth_creds    = [];
 
         foreach ($_COOKIE as $cookie_id => $cookie_content)
         {
@@ -499,7 +505,7 @@ do
     // PROCESS RESPONSE HEADERS
     //
 
-    $_response_headers = $_response_keys = array();
+    $_response_headers = $_response_keys = [];
 
     $line = fgets($_socket, 8192);
 
@@ -612,7 +618,7 @@ do
         }
         else
         {
-            show_report(array('which' => 'index', 'category' => 'auth', 'realm' => $matches[1]));
+            show_report(['which' => 'index', 'category' => 'auth', 'realm' => $matches[1]]);
         }
     }
 }
@@ -633,7 +639,7 @@ if (!isset($_proxify[$_content_type]))
     {
         if ($_config['max_file_size'] != -1 && $_content_length > $_config['max_file_size'])
         {
-            show_report(array('which' => 'index', 'category' => 'error', 'group' => 'resource', 'type' => 'file_size'));
+            show_report(['which' => 'index', 'category' => 'error', 'group' => 'resource', 'type' => 'file_size']);
         }
 
         $_response_keys['content-length'] = 'Content-Length';
@@ -708,43 +714,43 @@ else
 
     $tags = array
     (
-        'a'          => array('href', 'data-inbound-url', 'data-href-url'),
-        'img'        => array('src', 'longdesc', 'srcset', 'data-src'),
-        'image'      => array('src', 'longdesc'),
-        'body'       => array('background'),
-        'base'       => array('href'),
-        'frame'      => array('src', 'longdesc'),
-        'iframe'     => array('src', 'longdesc'),
-        'head'       => array('profile'),
-        'layer'      => array('src'),
-        'input'      => array('src', 'usemap'),
-        'form'       => array('action'),
-        'area'       => array('href'),
-        'link'       => array('href', 'src', 'urn', 'integrity'),
-        'meta'       => array('content'),
-        'param'      => array('value'),
-        'applet'     => array('codebase', 'code', 'object', 'archive'),
-        'object'     => array('usermap', 'codebase', 'classid', 'archive', 'data'),
-        'script'     => array('src'),
-        'select'     => array('src'),
-        'hr'         => array('src'),
-        'table'      => array('background'),
-        'tr'         => array('background'),
-        'th'         => array('background'),
-        'td'         => array('background'),
-        'bgsound'    => array('src'),
-        'blockquote' => array('cite'),
-        'del'        => array('cite'),
-        'embed'      => array('src'),
-        'fig'        => array('src', 'imagemap'),
-        'ilayer'     => array('src'),
-        'ins'        => array('cite'),
-        'note'       => array('src'),
-        'overlay'    => array('src', 'imagemap'),
-        'q'          => array('cite'),
-        'ul'         => array('src'),
-        'use'        => array('xlink:href'),
-        'source'     => array('srcset')
+        'a'          => ['href', 'data-inbound-url', 'data-href-url'],
+        'img'        => ['src', 'longdesc', 'srcset', 'data-src'],
+        'image'      => ['src', 'longdesc'],
+        'body'       => ['background'],
+        'base'       => ['href'],
+        'frame'      => ['src', 'longdesc'],
+        'iframe'     => ['src', 'longdesc'],
+        'head'       => ['profile'],
+        'layer'      => ['src'],
+        'input'      => ['src', 'usemap'],
+        'form'       => ['action'],
+        'area'       => ['href'],
+        'link'       => ['href', 'src', 'urn', 'integrity'],
+        'meta'       => ['content'],
+        'param'      => ['value'],
+        'applet'     => ['codebase', 'code', 'object', 'archive'],
+        'object'     => ['usermap', 'codebase', 'classid', 'archive', 'data'],
+        'script'     => ['src'],
+        'select'     => ['src'],
+        'hr'         => ['src'],
+        'table'      => ['background'],
+        'tr'         => ['background'],
+        'th'         => ['background'],
+        'td'         => ['background'],
+        'bgsound'    => ['src'],
+        'blockquote' => ['cite'],
+        'del'        => ['cite'],
+        'embed'      => ['src'],
+        'fig'        => ['src', 'imagemap'],
+        'ilayer'     => ['src'],
+        'ins'        => ['cite'],
+        'note'       => ['src'],
+        'overlay'    => ['src', 'imagemap'],
+        'q'          => ['cite'],
+        'ul'         => ['src'],
+        'use'        => ['xlink:href'],
+        'source'     => ['srcset'],
     );
 
     preg_match_all('#(<\s*style[^>]*>)(.*?)(<\s*/\s*style[^>]*>)#is', $_response_body, $matches, PREG_SET_ORDER);
@@ -765,7 +771,7 @@ else
 
         $rebuild    = false;
         $extra_html = $temp = '';
-        $attrs      = array();
+        $attrs      = [];
 
         for ($j = 0, $count_j = count($m); $j < $count_j; $attrs[strtolower($m[$j][1])] = (isset($m[$j][4]) ? $m[$j][4] : (isset($m[$j][3]) ? $m[$j][3] : (isset($m[$j][2]) ? $m[$j][2] : false))), ++$j);
 

--- a/index.php
+++ b/index.php
@@ -183,7 +183,7 @@ if ($_iflags !== '')
 
     foreach ($_flags as $flag_name => $flag_value)
     {
-        $_flags[$flag_name] = $_frozen_flags[$flag_name] ? $flag_value : (int)(bool)$_iflags{$i};
+        $_flags[$flag_name] = $_frozen_flags[$flag_name] ? $flag_value : (int)(bool)$_iflags[$i];
         $i++;
     }
 }

--- a/index.php
+++ b/index.php
@@ -203,7 +203,7 @@ if ($_config['compress_output'] && $_system['gzip'])
 
 if ($_system['stripslashes'])
 {
-    function _stripslashes($value)
+    function _stripslashes(mixed $value): mixed
     {
         return is_array($value) ? array_map('_stripslashes', $value) : (is_string($value) ? stripslashes($value) : $value);
     }

--- a/index.php
+++ b/index.php
@@ -14,8 +14,8 @@
  *
  */
 
-
-error_reporting(0);
+/* PRODUCTIVE: */ error_reporting(0);
+//* DEVELOP: */ error_reporting(E_ALL | E_STRICT);
 
 //
 // CONFIGURABLE OPTIONS
@@ -130,7 +130,7 @@ $_basic_auth_header = '';
 $_basic_auth_realm  = '';
 $_auth_creds        = [];
 $_response_body     = '';
-$pos = $_COOKIE['userAgent'];
+$pos = isset($_COOKIE['userAgent']) ? $_COOKIE['userAgent'] : null;
 if(!isset($pos) || $pos == ""){ // empty means old method
   $_user_agent = isset($_SERVER['HTTP_X_IORG_FBS']) ? 'SamsungI8910/SymbianOS/6.1 PHProxy/'.$_version : $_SERVER['HTTP_USER_AGENT'];
 }else if($pos == '.'){ // dot means use the browsers UA
@@ -436,8 +436,12 @@ do
     {
         $_request_headers  .= "Authorization: Basic {$_auth_creds[$_basic_auth_realm]}\r\n";
     }
-    else if (list($_basic_auth_realm, $_basic_auth_header) = each($_auth_creds))
+    else if (count($_auth_creds) >= 2)
     {
+        $_dummy = array_values($_auth_creds);
+        $_basic_auth_realm = $dummy[0];
+        $_basic_auth_header = $dummy[1];
+
         $_request_headers .= "Authorization: Basic {$_basic_auth_header}\r\n";
     }
     if ($_request_method == 'POST')


### PR DESCRIPTION
This PR contains changes towards PHP8 compatibility:
- Function `each()` is no longer available, also checking an assignment of a value/reference should not be done anymore
- added many type-hints
- Used "new" way `[`]` for arrays instead of `array()`
- Arrays now nicer formatted