### PR TITLE
Modernise the interface

### DIFF
--- a/edit.php
+++ b/edit.php
@@ -7,48 +7,49 @@ if (isset($_POST['action']) && $_POST['action'] == "submit") {
     }
 }
 ?>
-<html>
+<!DOCTYPE html>
+<html lang="en">
 <head>
-	<meta charset="UTF-8"/>
-	<meta name="viewport" content="width=device-width, initial-scale=1"/>
-	<title>Settings</title>
-	<link rel="stylesheet" href="./files/css/index.css"/>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <title>Settings &middot; PHProxy</title>
+    <link rel="stylesheet" href="./files/css/index.css"/>
 </head>
 <body>
 <form action="<?php echo htmlspecialchars($_SERVER['PHP_SELF']); ?>" method="post">
-	<div class="main">
-		<div class="form-title-row">
-			<h1>Settings</h1>
-		</div>
-		<div class="form-row">
-			<label>
-				<span>User Agent:</span>
-				<input value="<?php if (isset($_COOKIE['userAgent'])) {echo (htmlspecialchars($_COOKIE['userAgent']));} else {echo "";}?>" type="text" list="user-agents" id="userAgent" name="userAgent" placeholder=""/>
- 				<datalist id="user-agents">
-					<option value="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko)" label="MS Edge Running on Windows"/>
-					<option value="Mozilla/5.0 (iPhone; CPU iPhone OS 8_0_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile Safari/600.1.4" label="Apple iOS (iPhone)"/>
-					<option value="Mozilla/5.0 (Linux; U; Android 4.4.4; Nexus 5 Build/KTU84P) AppleWebkit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30" label="Google Android (Nexus 5)"/>
-					<option value="Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0)" label="Microsoft Windows Phone"/>
-					<option value="Mozilla/5.0 (Linux; U; Tizen 2.0; en-us) AppleWebKit/537.1 (KHTML, like Gecko) Mobile TizenBrowser/2.0" label="Samsung Tizen OS"/>
-					<option value="Nokia5250/10.0.011 (SymbianOS/9.4; U; Series60/5.0 Mozilla/5.0; Profile/MIDP-2.1 Configuration/CLDC-1.1 ) AppleWebKit/525 (KHTML, like Gecko) Safari/525 3gpp-gba" label="Nokia Symbian"/>
-					<option value="Mozilla/5.0 (Android 4.4; Mobile; rv:18.0) Gecko/18.0 Firefox/18.0" label="Mozilla Firefox OS"/>
-					<option value="Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36" label="Chrome Running on MS Windows"/>
-					<option value="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2227.1 Safari/537.36" label="Chrome Running on Linux"/>
-					<option value="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2227.0 Safari/537.36" label="Chrome Running on Mac OS"/>
-					<option value="Mozilla/5.0 (X11; CrOS i686 3912.101.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.116 Safari/537.36" label="Chrome Running on Chrome OS"/>
-					<option value="Mozilla/5.0 (X11; FreeBSD amd64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.115 Safari/537.36" label="Chrome Running on FreeBSD OS"/>
-					<option value="." label="Use browser"/>
-					<option value="-" label="None"/>
-					<option value="" label="Default"/>
-				</datalist>
-			</label>
-		</div>
-		<div class="form-row">
-			<button class="button-submit" type="submit" name="action" value="submit">Submit</button>
-			<button class="button-submit" type="reset" name="action" value="reset">Reset</button>
-			<a class="button-submit" href="index.php">Back</a>
-		</div>
-	</div>
+    <div class="main">
+        <div class="form-title-row">
+            <h1>Settings</h1>
+        </div>
+        <div class="form-row">
+            <label>
+                <span>User Agent</span>
+                <input value="<?php if (isset($_COOKIE['userAgent'])) { echo htmlspecialchars($_COOKIE['userAgent']); } ?>" type="text" list="user-agents" id="userAgent" name="userAgent" placeholder="Default browser User-Agent" autocomplete="off"/>
+                <datalist id="user-agents">
+                    <option value="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko)" label="MS Edge on Windows"/>
+                    <option value="Mozilla/5.0 (iPhone; CPU iPhone OS 8_0_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile Safari/600.1.4" label="Apple iOS (iPhone)"/>
+                    <option value="Mozilla/5.0 (Linux; U; Android 4.4.4; Nexus 5 Build/KTU84P) AppleWebkit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30" label="Google Android (Nexus 5)"/>
+                    <option value="Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0)" label="Microsoft Windows Phone"/>
+                    <option value="Mozilla/5.0 (Linux; U; Tizen 2.0; en-us) AppleWebKit/537.1 (KHTML, like Gecko) Mobile TizenBrowser/2.0" label="Samsung Tizen OS"/>
+                    <option value="Nokia5250/10.0.011 (SymbianOS/9.4; U; Series60/5.0 Mozilla/5.0; Profile/MIDP-2.1 Configuration/CLDC-1.1 ) AppleWebKit/525 (KHTML, like Gecko) Safari/525 3gpp-gba" label="Nokia Symbian"/>
+                    <option value="Mozilla/5.0 (Android 4.4; Mobile; rv:18.0) Gecko/18.0 Firefox/18.0" label="Mozilla Firefox OS"/>
+                    <option value="Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36" label="Chrome on MS Windows"/>
+                    <option value="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2227.1 Safari/537.36" label="Chrome on Linux"/>
+                    <option value="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2227.0 Safari/537.36" label="Chrome on macOS"/>
+                    <option value="Mozilla/5.0 (X11; CrOS i686 3912.101.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.116 Safari/537.36" label="Chrome on Chrome OS"/>
+                    <option value="Mozilla/5.0 (X11; FreeBSD amd64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.115 Safari/537.36" label="Chrome on FreeBSD"/>
+                    <option value="." label="Use browser User-Agent"/>
+                    <option value="-" label="No User-Agent"/>
+                    <option value="" label="Default"/>
+                </datalist>
+            </label>
+        </div>
+        <div class="form-row">
+            <button class="button-submit" type="submit" name="action" value="submit">Save</button>
+            <button class="button-cancel" type="reset" name="action" value="reset">Reset</button>
+            <a class="button-cancel" href="index.php">Back</a>
+        </div>
+    </div>
 </form>
 </body>
 </html>

--- a/files/css/index.css
+++ b/files/css/index.css
@@ -1,191 +1,279 @@
+:root {
+    --bg: #f7f8fa;
+    --surface: #ffffff;
+    --border: #e2e6ec;
+    --text: #1f2937;
+    --text-muted: #6b7280;
+    --accent: #2563eb;
+    --accent-hover: #1d4ed8;
+    --accent-ring: rgba(37, 99, 235, .18);
+    --danger: #ef4444;
+    --danger-soft: #fee2e2;
+    --warning: #f59e0b;
+    --warning-soft: #fef3c7;
+    --success: #10b981;
+    --success-soft: #d1fae5;
+    --radius: 8px;
+    --shadow: 0 10px 15px -3px rgba(0, 0, 0, .07), 0 4px 6px -4px rgba(0, 0, 0, .05);
+    --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg: #0f172a;
+        --surface: #1e293b;
+        --border: #334155;
+        --text: #f1f5f9;
+        --text-muted: #94a3b8;
+        --accent: #3b82f6;
+        --accent-hover: #60a5fa;
+        --accent-ring: rgba(59, 130, 246, .25);
+        --danger: #f87171;
+        --danger-soft: #7f1d1d;
+        --warning: #fbbf24;
+        --warning-soft: #78350f;
+        --success: #34d399;
+        --success-soft: #064e3b;
+        --shadow: 0 10px 15px -3px rgba(0, 0, 0, .35), 0 4px 6px -4px rgba(0, 0, 0, .25);
+    }
+}
+
 * {
-	padding: 0;
-	margin: 0
+    box-sizing: border-box;
 }
+
+html,
 body {
-	background: #f3f3f3;
-	font: 400 16px sans-serif;
-	color: #555;
+    margin: 0;
+    padding: 0;
 }
+
+body {
+    background: var(--bg);
+    color: var(--text);
+    font: 400 16px/1.5 var(--font);
+    -webkit-font-smoothing: antialiased;
+}
+
 .main {
-	box-sizing: border-box;
-	width: 100%;
-	max-width: 500px;
-	min-width: 350px;
-	margin: 50px auto;
-	padding: 55px;
-	background-color: #fff;
-	box-shadow: 6px 6px 20px 0px rgba(0, 0, 0, 0.5);
-	font: 400 14px sans-serif;
-	text-align: center;
+    width: 100%;
+    max-width: 480px;
+    margin: 48px auto;
+    padding: 32px;
+    background-color: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    font-size: 14px;
 }
+
 .main-auth-box {
-	box-shadow: 6px 6px 20px 0px rgba(255, 0, 0, 0.29)!important;
+    border-color: var(--danger);
 }
+
 .form-title-row {
-	margin: 0 auto 40px auto;
-	text-align: left;
+    margin-bottom: 24px;
 }
+
 .form-title-row h1 {
-	display: block;
-	box-sizing: border-box;
-	color: #4C565E;
-	font-size: 24px;
-	padding: 0 0 3px;
-	margin: 0;
-	border-bottom: 2px solid #6CAEE0;
+    margin: 0;
+    padding-bottom: 8px;
+    color: var(--text);
+    font-size: 20px;
+    font-weight: 600;
+    letter-spacing: -.01em;
+    border-bottom: 2px solid var(--accent);
 }
-.form-row {
-	text-align: left;
-}
-.form-row label span {
-	display: block;
-	box-sizing: border-box;
-	color: #5f5f5f;
-	padding: 0 0 10px;
-	font-weight: 700;
-}
-form input {
-	color: #5f5f5f;
-	box-sizing: border-box;
-	box-shadow: 1px 2px 4px 0 rgba(0, 0, 0, .08);
-	padding: 12px 18px;
-	border: 1px solid #dbdbdb;
-	margin-bottom: 10px;
-}
-form input[type=email], form input[type=username], form input[type=password], form input[type=text], form textarea {
-	width: 100%
-}
-form input[type=number] {
-	max-width: 100px
-}
-form input[type=checkbox], form input[type=radio] {
-	box-shadow: none;
-	width: auto
-}
-form textarea {
-	color: #5f5f5f;
-	box-sizing: border-box;
-	box-shadow: 1px 2px 4px 0 rgba(0, 0, 0, .08);
-	padding: 12px 18px;
-	border: 1px solid #dbdbdb;
-	resize: none;
-	min-height: 80px;
-}
-form select {
-	background-color: #fff;
-	color: #5f5f5f;
-	box-sizing: border-box;
-	width: 240px;
-	box-shadow: 1px 2px 4px 0 rgba(0, 0, 0, .08);
-	padding: 12px 18px;
-	border: 1px solid #dbdbdb
-}
-form .form-radio-buttons>div {
-	margin-bottom: 10px
-}
-form .form-radio-buttons label span {
-	margin-left: 8px;
-	color: #5f5f5f
-}
-form .form-radio-buttons input {
-	width: auto
-}
-.button-submit {
-	border-radius: 2px;
-	background-color: #6caee0;
-	color: #fff;
-	font: 700 13.3333px Arial;
-	box-shadow: 1px 2px 4px 0 rgba(0, 0, 0, .08);
-	padding: 14px 22px;
-	border: 0;
-	margin-top: 10px;
-	cursor: pointer;
-	text-decoration: none;
-}
-.button-cancel {
-	border-radius: 2px;
-	background-color: #a4bbcc;
-	color: #fff;
-	font: 700 13.3333px Arial;
-	box-shadow: 1px 2px 4px 0 rgba(0, 0, 0, .08);
-	padding: 14px 22px;
-	border: 0;
-	margin-top: 10px;
-	cursor: pointer;
-	text-decoration: none;
-}
-p.explanation {
-	padding: 15px 20px;
-	line-height: 1.5;
-	background-color: #FFFFE0;
-	font-size: 13px;
-	text-align: center;
-	margin-top: 40px;
-	color: #6B6B48;
-	border-radius: 3px;
-	border-bottom: 2px solid #ECECD0;
-	border-right: 2px solid #ECECD0;
-	text-align: left
-}
-p.error {
-	padding: 15px 20px;
-	line-height: 1.5;
-	background-color: #ff7272;
-	font-size: 13px;
-	text-align: center;
-	margin-top: 40px;
-	color: #ffffff;
-	border-radius: 3px;
-	border-bottom: 2px solid #fd3333;
-	border-right: 2px solid #c1294c;
-	text-align: left;
-}
-p.info {
-	padding: 15px 20px;
-	line-height: 1.5;
-	background-color: #56dcb1;
-	font-size: 13px;
-	text-align: center;
-	margin-top: 40px;
-	color: #ffffff;
-	border-radius: 3px;
-	border-bottom: 2px solid #76dc75;
-	border-right: 2px solid #30cc2e;
-	text-align: left;
-}
+
 .auth-header {
-	border-bottom: 2px solid #ff8100 !important;
+    border-bottom-color: var(--warning) !important;
 }
+
+.form-row {
+    margin-bottom: 16px;
+}
+
+.form-row label span {
+    display: block;
+    margin-bottom: 6px;
+    color: var(--text-muted);
+    font-size: 13px;
+    font-weight: 500;
+}
+
+form input,
+form textarea,
+form select {
+    width: 100%;
+    padding: 10px 14px;
+    color: var(--text);
+    background-color: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    font: inherit;
+    transition: border-color .15s ease, box-shadow .15s ease;
+}
+
+form input:focus,
+form textarea:focus,
+form select:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px var(--accent-ring);
+}
+
+form input[type=checkbox],
+form input[type=radio] {
+    width: auto;
+    margin-right: 8px;
+    accent-color: var(--accent);
+}
+
+form input[type=number] {
+    max-width: 120px;
+}
+
+form select {
+    max-width: 280px;
+}
+
+form textarea {
+    min-height: 80px;
+    resize: vertical;
+}
+
+.button-submit,
+.button-cancel {
+    display: inline-block;
+    padding: 10px 18px;
+    font: 600 14px var(--font);
+    text-decoration: none;
+    border: 0;
+    border-radius: var(--radius);
+    cursor: pointer;
+    transition: background-color .15s ease, color .15s ease;
+}
+
+.button-submit {
+    background-color: var(--accent);
+    color: #fff;
+}
+
+.button-submit:hover,
+.button-submit:focus {
+    background-color: var(--accent-hover);
+}
+
+.button-cancel {
+    background-color: transparent;
+    color: var(--text-muted);
+    border: 1px solid var(--border);
+}
+
+.button-cancel:hover,
+.button-cancel:focus {
+    color: var(--text);
+    border-color: var(--text-muted);
+}
+
+p.explanation,
+p.error,
+p.info {
+    margin: 24px 0 0;
+    padding: 12px 16px;
+    border-radius: var(--radius);
+    font-size: 13px;
+    line-height: 1.5;
+}
+
+p.explanation {
+    background-color: var(--warning-soft);
+    color: var(--text);
+    border-left: 3px solid var(--warning);
+}
+
+p.error {
+    background-color: var(--danger-soft);
+    color: var(--text);
+    border-left: 3px solid var(--danger);
+}
+
+p.info {
+    background-color: var(--success-soft);
+    color: var(--text);
+    border-left: 3px solid var(--success);
+}
+
 .auth {
-	margin-top: 10px;
+    margin-top: 16px;
 }
+
 .prx-opt-menu {
-	list-style: none;
-	text-align: initial;
-	padding-left: 4%;
+    list-style: none;
+    margin: 0;
+    padding: 0;
 }
-.option label input {
-	margin-right: 10px;
+
+.option {
+    padding: 10px 0;
+    border-bottom: 1px solid var(--border);
 }
-@media (max-width:600px) {
-	.main {
-		padding: 30px
-	}
-	body {
-		background: #fff;
-	}
-	.main {
-		box-shadow: none;
-	}
+
+.option:last-child {
+    border-bottom: 0;
 }
+
+.option label {
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+}
+
 #proxopttogl {
-	position: absolute;
-	left: -12em;
+    position: absolute;
+    left: -9999px;
 }
+
 #proxopttogl~#proxoptmenu {
-	display: none;
+    display: none;
 }
+
 #proxopttogl:checked~#proxoptmenu {
-	display: block;
+    display: block;
+}
+
+.more-link {
+    display: inline-block;
+    margin-top: 16px;
+    color: var(--accent);
+    font-size: 13px;
+    text-decoration: none;
+}
+
+.more-link:hover {
+    color: var(--accent-hover);
+}
+
+.footer {
+    margin: 24px auto;
+    text-align: center;
+    font-size: 12px;
+    color: var(--text-muted);
+}
+
+.footer a {
+    color: var(--text-muted);
+    text-decoration: none;
+}
+
+.footer a:hover {
+    color: var(--accent);
+}
+
+@media (max-width: 600px) {
+    .main {
+        margin: 16px;
+        padding: 24px;
+        box-shadow: none;
+    }
 }

--- a/files/css/index.css
+++ b/files/css/index.css
@@ -1,11 +1,14 @@
 :root {
-    --bg: #f7f8fa;
+    --bg: #f4f5f7;
     --surface: #ffffff;
+    --surface-2: #f8fafc;
     --border: #e2e6ec;
-    --text: #1f2937;
-    --text-muted: #6b7280;
+    --border-strong: #cbd5e1;
+    --text: #0f172a;
+    --text-muted: #64748b;
     --accent: #2563eb;
     --accent-hover: #1d4ed8;
+    --accent-soft: #dbeafe;
     --accent-ring: rgba(37, 99, 235, .18);
     --danger: #ef4444;
     --danger-soft: #fee2e2;
@@ -13,29 +16,58 @@
     --warning-soft: #fef3c7;
     --success: #10b981;
     --success-soft: #d1fae5;
-    --radius: 8px;
-    --shadow: 0 10px 15px -3px rgba(0, 0, 0, .07), 0 4px 6px -4px rgba(0, 0, 0, .05);
+    --radius: 10px;
+    --radius-sm: 6px;
+    --shadow: 0 10px 15px -3px rgba(15, 23, 42, .06), 0 4px 6px -4px rgba(15, 23, 42, .04);
     --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, monospace;
+    color-scheme: light;
 }
 
 @media (prefers-color-scheme: dark) {
-    :root {
-        --bg: #0f172a;
-        --surface: #1e293b;
-        --border: #334155;
+    :root:not([data-theme="light"]) {
+        --bg: #0b1220;
+        --surface: #131c2e;
+        --surface-2: #1a2438;
+        --border: #2a374e;
+        --border-strong: #3b4a66;
         --text: #f1f5f9;
         --text-muted: #94a3b8;
-        --accent: #3b82f6;
-        --accent-hover: #60a5fa;
-        --accent-ring: rgba(59, 130, 246, .25);
+        --accent: #60a5fa;
+        --accent-hover: #93c5fd;
+        --accent-soft: #1e3a8a;
+        --accent-ring: rgba(96, 165, 250, .25);
         --danger: #f87171;
         --danger-soft: #7f1d1d;
         --warning: #fbbf24;
         --warning-soft: #78350f;
         --success: #34d399;
         --success-soft: #064e3b;
-        --shadow: 0 10px 15px -3px rgba(0, 0, 0, .35), 0 4px 6px -4px rgba(0, 0, 0, .25);
+        --shadow: 0 10px 15px -3px rgba(0, 0, 0, .4), 0 4px 6px -4px rgba(0, 0, 0, .25);
+        color-scheme: dark;
     }
+}
+
+:root[data-theme="dark"] {
+    --bg: #0b1220;
+    --surface: #131c2e;
+    --surface-2: #1a2438;
+    --border: #2a374e;
+    --border-strong: #3b4a66;
+    --text: #f1f5f9;
+    --text-muted: #94a3b8;
+    --accent: #60a5fa;
+    --accent-hover: #93c5fd;
+    --accent-soft: #1e3a8a;
+    --accent-ring: rgba(96, 165, 250, .25);
+    --danger: #f87171;
+    --danger-soft: #7f1d1d;
+    --warning: #fbbf24;
+    --warning-soft: #78350f;
+    --success: #34d399;
+    --success-soft: #064e3b;
+    --shadow: 0 10px 15px -3px rgba(0, 0, 0, .4), 0 4px 6px -4px rgba(0, 0, 0, .25);
+    color-scheme: dark;
 }
 
 * {
@@ -55,31 +87,95 @@ body {
     -webkit-font-smoothing: antialiased;
 }
 
-.main {
+.page {
     width: 100%;
-    max-width: 480px;
-    margin: 48px auto;
-    padding: 32px;
+    max-width: 640px;
+    margin: 32px auto;
+    padding: 0 16px;
+}
+
+.appbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 20px;
+}
+
+.appbar h1 {
+    margin: 0;
+    color: var(--text);
+    font-size: 22px;
+    font-weight: 700;
+    letter-spacing: -.01em;
+}
+
+.appbar h1 .dot {
+    color: var(--accent);
+}
+
+.theme-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    padding: 0;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: background-color .15s, color .15s, border-color .15s;
+}
+
+.theme-toggle:hover,
+.theme-toggle:focus-visible {
+    background: var(--surface-2);
+    color: var(--text);
+    border-color: var(--border-strong);
+    outline: none;
+}
+
+.theme-toggle svg {
+    width: 18px;
+    height: 18px;
+    display: block;
+}
+
+.theme-toggle .icon-moon { display: none; }
+.theme-toggle .icon-sun { display: block; }
+
+:root[data-theme="dark"] .theme-toggle .icon-moon { display: block; }
+:root[data-theme="dark"] .theme-toggle .icon-sun { display: none; }
+
+@media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) .theme-toggle .icon-moon { display: block; }
+    :root:not([data-theme="light"]) .theme-toggle .icon-sun { display: none; }
+}
+
+.card {
     background-color: var(--surface);
     border: 1px solid var(--border);
     border-radius: var(--radius);
     box-shadow: var(--shadow);
-    font-size: 14px;
+    padding: 20px;
+    margin-bottom: 16px;
 }
 
-.main-auth-box {
-    border-color: var(--danger);
+.card + .card {
+    margin-top: 16px;
 }
 
 .form-title-row {
-    margin-bottom: 24px;
+    margin-bottom: 16px;
 }
 
-.form-title-row h1 {
+.form-title-row h1,
+.form-title-row h2 {
     margin: 0;
     padding-bottom: 8px;
     color: var(--text);
-    font-size: 20px;
+    font-size: 18px;
     font-weight: 600;
     letter-spacing: -.01em;
     border-bottom: 2px solid var(--accent);
@@ -89,8 +185,16 @@ body {
     border-bottom-color: var(--warning) !important;
 }
 
+.main-auth-box {
+    border-color: var(--danger);
+}
+
 .form-row {
-    margin-bottom: 16px;
+    margin-bottom: 14px;
+}
+
+.form-row:last-child {
+    margin-bottom: 0;
 }
 
 .form-row label span {
@@ -101,6 +205,17 @@ body {
     font-weight: 500;
 }
 
+.url-row {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.url-row .url-input {
+    flex: 1 1 320px;
+    min-width: 0;
+}
+
 form input,
 form textarea,
 form select {
@@ -109,9 +224,9 @@ form select {
     color: var(--text);
     background-color: var(--surface);
     border: 1px solid var(--border);
-    border-radius: var(--radius);
+    border-radius: var(--radius-sm);
     font: inherit;
-    transition: border-color .15s ease, box-shadow .15s ease;
+    transition: border-color .15s, box-shadow .15s;
 }
 
 form input:focus,
@@ -129,133 +244,178 @@ form input[type=radio] {
     accent-color: var(--accent);
 }
 
-form input[type=number] {
-    max-width: 120px;
-}
-
-form select {
-    max-width: 280px;
-}
-
-form textarea {
-    min-height: 80px;
-    resize: vertical;
-}
+form input[type=number] { max-width: 120px; }
+form select { max-width: 280px; }
+form textarea { min-height: 80px; resize: vertical; }
 
 .button-submit,
-.button-cancel {
-    display: inline-block;
-    padding: 10px 18px;
+.button-cancel,
+.button-ghost {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px 16px;
     font: 600 14px var(--font);
     text-decoration: none;
     border: 0;
-    border-radius: var(--radius);
+    border-radius: var(--radius-sm);
     cursor: pointer;
-    transition: background-color .15s ease, color .15s ease;
+    transition: background-color .15s, color .15s, border-color .15s;
+    white-space: nowrap;
 }
 
 .button-submit {
     background-color: var(--accent);
     color: #fff;
 }
-
 .button-submit:hover,
-.button-submit:focus {
-    background-color: var(--accent-hover);
-}
+.button-submit:focus { background-color: var(--accent-hover); }
 
 .button-cancel {
-    background-color: transparent;
+    background: transparent;
     color: var(--text-muted);
     border: 1px solid var(--border);
 }
-
 .button-cancel:hover,
 .button-cancel:focus {
     color: var(--text);
-    border-color: var(--text-muted);
+    border-color: var(--border-strong);
+}
+
+.button-ghost {
+    background: transparent;
+    color: var(--danger);
+    border: 1px solid var(--border);
+}
+.button-ghost:hover,
+.button-ghost:focus {
+    color: #fff;
+    background-color: var(--danger);
+    border-color: var(--danger);
 }
 
 p.explanation,
 p.error,
 p.info {
-    margin: 24px 0 0;
+    margin: 16px 0 0;
     padding: 12px 16px;
-    border-radius: var(--radius);
+    border-radius: var(--radius-sm);
     font-size: 13px;
     line-height: 1.5;
 }
+p.explanation { background: var(--warning-soft); color: var(--text); border-left: 3px solid var(--warning); }
+p.error { background: var(--danger-soft); color: var(--text); border-left: 3px solid var(--danger); }
+p.info { background: var(--success-soft); color: var(--text); border-left: 3px solid var(--success); }
 
-p.explanation {
-    background-color: var(--warning-soft);
-    color: var(--text);
-    border-left: 3px solid var(--warning);
-}
-
-p.error {
-    background-color: var(--danger-soft);
-    color: var(--text);
-    border-left: 3px solid var(--danger);
-}
-
-p.info {
-    background-color: var(--success-soft);
-    color: var(--text);
-    border-left: 3px solid var(--success);
-}
-
-.auth {
+.tabs-wrap {
     margin-top: 16px;
+}
+
+.tabs-wrap > input[type="radio"] {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.tabs {
+    display: flex;
+    gap: 4px;
+    border-bottom: 1px solid var(--border);
+    margin-bottom: 16px;
+}
+
+.tabs label {
+    padding: 8px 14px;
+    color: var(--text-muted);
+    font-size: 14px;
+    font-weight: 500;
+    border-bottom: 2px solid transparent;
+    margin-bottom: -1px;
+    cursor: pointer;
+    transition: color .15s, border-color .15s;
+}
+
+.tabs label:hover { color: var(--text); }
+
+#tab-options:checked ~ .tabs label[for="tab-options"],
+#tab-cookies:checked ~ .tabs label[for="tab-cookies"],
+#tab-headers:checked ~ .tabs label[for="tab-headers"] {
+    color: var(--accent);
+    border-bottom-color: var(--accent);
+}
+
+.tab-panel { display: none; }
+
+#tab-options:checked ~ .tab-panel[data-tab="options"],
+#tab-cookies:checked ~ .tab-panel[data-tab="cookies"],
+#tab-headers:checked ~ .tab-panel[data-tab="headers"] {
+    display: block;
 }
 
 .prx-opt-menu {
     list-style: none;
     margin: 0;
     padding: 0;
-}
-
-.option {
-    padding: 10px 0;
-    border-bottom: 1px solid var(--border);
-}
-
-.option:last-child {
-    border-bottom: 0;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 6px 16px;
 }
 
 .option label {
     display: flex;
     align-items: center;
+    gap: 8px;
+    padding: 6px 0;
+    color: var(--text);
+    font-size: 14px;
     cursor: pointer;
 }
 
-#proxopttogl {
-    position: absolute;
-    left: -9999px;
+.option label input { margin: 0; }
+
+.cookie-list {
+    list-style: none;
+    margin: 0 0 16px;
+    padding: 0;
+    max-height: 220px;
+    overflow-y: auto;
 }
 
-#proxopttogl~#proxoptmenu {
-    display: none;
+.cookie-list li {
+    display: flex;
+    justify-content: space-between;
+    padding: 8px 12px;
+    background: var(--surface-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    margin-bottom: 4px;
+    font: 13px var(--font-mono);
+    color: var(--text);
+    word-break: break-all;
 }
 
-#proxopttogl:checked~#proxoptmenu {
-    display: block;
+.cookie-list .empty {
+    background: transparent;
+    border: 1px dashed var(--border);
+    color: var(--text-muted);
+    font: 13px var(--font);
+    justify-content: center;
 }
 
-.more-link {
-    display: inline-block;
-    margin-top: 16px;
-    color: var(--accent);
+.tab-actions {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.tab-help {
+    margin: 0 0 12px;
+    color: var(--text-muted);
     font-size: 13px;
-    text-decoration: none;
-}
-
-.more-link:hover {
-    color: var(--accent-hover);
 }
 
 .footer {
-    margin: 24px auto;
+    margin: 24px 0;
     text-align: center;
     font-size: 12px;
     color: var(--text-muted);
@@ -266,14 +426,10 @@ p.info {
     text-decoration: none;
 }
 
-.footer a:hover {
-    color: var(--accent);
-}
+.footer a:hover { color: var(--accent); }
 
 @media (max-width: 600px) {
-    .main {
-        margin: 16px;
-        padding: 24px;
-        box-shadow: none;
-    }
+    .page { margin: 16px auto; padding: 0 12px; }
+    .card { padding: 16px; }
+    .prx-opt-menu { grid-template-columns: 1fr; }
 }

--- a/files/php/index.inc.php
+++ b/files/php/index.inc.php
@@ -3,244 +3,32 @@ if (basename(__FILE__) == basename($_SERVER['PHP_SELF'])) {
     exit(0);
 }
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
-	<head>
-		<title><?php echo htmlspecialchars($GLOBALS['_config']['site_name']); ?></title>
-<style>
-		* {
-			padding: 0;
-			margin: 0
-		}
-		body {
-			background: #f3f3f3;
-			font: 400 16px sans-serif;
-			color: #555;
-		}
-		.main {
-			box-sizing: border-box;
-			width: 100%;
-			max-width: 500px;
-			min-width: 350px;
-			margin: 50px auto;
-			padding: 55px;
-			background-color: #fff;
-			box-shadow: 6px 6px 20px 0px rgba(0, 0, 0, 0.5);
-			font: 400 14px sans-serif;
-			text-align: center;
-		}
-		.main-auth-box {
-			box-shadow: 6px 6px 20px 0px rgba(255, 0, 0, 0.29)!important;
-		}
-		.form-title-row {
-			margin: 0 auto 40px auto;
-			text-align: left;
-		}
-		.form-title-row h1 {
-			display: block;
-			box-sizing: border-box;
-			color: #4C565E;
-			font-size: 24px;
-			padding: 0 0 3px;
-			margin: 0;
-			border-bottom: 2px solid #6CAEE0;
-		}
-		.form-row {
-			text-align: left;
-		}
-		.form-row label span{
-			display: block;
-			box-sizing: border-box;
-			color: #5f5f5f;
-			padding: 0 0 10px;
-			font-weight: 700;
-		}
-		form input {
-			color: #5f5f5f;
-			box-sizing: border-box;
-			box-shadow: 1px 2px 4px 0 rgba(0, 0, 0, .08);
-			padding: 12px 18px;
-			border: 1px solid #dbdbdb;
-			margin-bottom: 10px;
-		}
-
-		form input[type=email],
-		form input[type=username],
-		form input[type=password],
-		form input[type=text],
-		form textarea {
-			width: 100%
-		}
-
-		form input[type=number] {
-			max-width: 100px
-		}
-
-		form input[type=checkbox],
-		form input[type=radio] {
-			box-shadow: none;
-			width: auto
-		}
-
-		form textarea {
-			color: #5f5f5f;
-			box-sizing: border-box;
-			box-shadow: 1px 2px 4px 0 rgba(0, 0, 0, .08);
-			padding: 12px 18px;
-			border: 1px solid #dbdbdb;
-			resize: none;
-			min-height: 80px;
-		}
-
-		form select {
-			background-color: #fff;
-			color: #5f5f5f;
-			box-sizing: border-box;
-			width: 240px;
-			box-shadow: 1px 2px 4px 0 rgba(0, 0, 0, .08);
-			padding: 12px 18px;
-			border: 1px solid #dbdbdb
-		}
-
-		form .form-radio-buttons>div {
-			margin-bottom: 10px
-		}
-
-		form .form-radio-buttons label span {
-			margin-left: 8px;
-			color: #5f5f5f
-		}
-
-		form .form-radio-buttons input {
-			width: auto
-		}
-
-		.button-submit {
-			border-radius: 2px;
-			background-color: #6caee0;
-			color: #fff;
-			font: 700 13.3333px Arial;
-			box-shadow: 1px 2px 4px 0 rgba(0, 0, 0, .08);
-			padding: 14px 22px;
-			border: 0;
-			margin-top: 10px;
-			cursor: pointer;
-			text-decoration: none;
-		}
-		.button-cancel {
-			border-radius: 2px;
-			background-color: #a4bbcc;
-			color: #fff;
-			font: 700 13.3333px Arial;
-			box-shadow: 1px 2px 4px 0 rgba(0, 0, 0, .08);
-			padding: 14px 22px;
-			border: 0;
-			margin-top: 10px;
-			cursor: pointer;
-			text-decoration: none;
-		}
-		p.explanation {
-			padding: 15px 20px;
-			line-height: 1.5;
-			background-color: #FFFFE0;
-			font-size: 13px;
-			text-align: center;
-			margin-top: 40px;
-			color: #6B6B48;
-			border-radius: 3px;
-			border-bottom: 2px solid #ECECD0;
-			border-right: 2px solid #ECECD0;
-			text-align: left
-		}
-		p.error {
-			padding: 15px 20px;
-			line-height: 1.5;
-			background-color: #ff7272;
-			font-size: 13px;
-			text-align: center;
-			margin-top: 40px;
-			color: #ffffff;
-			border-radius: 3px;
-			border-bottom: 2px solid #fd3333;
-			border-right: 2px solid #c1294c;
-			text-align: left;
-		}
-
-		p.info {
-			padding: 15px 20px;
-			line-height: 1.5;
-			background-color: #56dcb1;
-			font-size: 13px;
-			text-align: center;
-			margin-top: 40px;
-			color: #ffffff;
-			border-radius: 3px;
-			border-bottom: 2px solid #76dc75;
-			border-right: 2px solid #30cc2e;
-			text-align: left;
-		}
-
-		.auth-header {
-			border-bottom: 2px solid #ff8100 !important;
-		}
-
-		.auth {
-			margin-top: 10px;
-		}
-
-		.prx-opt-menu {
-			list-style: none;
-			text-align: initial;
-			padding-left: 4%;
-		}
-		.option label input {
-			margin-right: 10px;
-		}
-
-		@media (max-width:600px) {
-			.main {
-				padding: 30px
-			}
-			body {
-				background: #fff;
-			}
-			.main {
-				box-shadow: none;
-			}
-		}
-		#proxopttogl {
-			position: absolute;
-			left: -12em;
-		}
-
-		#proxopttogl ~ #proxoptmenu {
-			display : none;
-		}
-
-		#proxopttogl:checked ~ #proxoptmenu {
-			display : block;
-		}
-		</style>
-		<meta name="viewport" content="width=device-width, initial-scale=1"/>
-		<script src="./files/js/index.js"></script>
-	</head>
-	<body>
-	<?php if ($data['category'] != 'auth'): ?>
-	<form method="post" action="<?php echo htmlspecialchars($_SERVER['PHP_SELF']); ?>">
-		<div class="main">
-			<div class="form-title-row">
-				<h1><?php echo htmlspecialchars($GLOBALS['_config']['site_name']); ?></h1>
-			</div>
-			<div class="form-row">
-				<label>
-					<span>Enter full URL:</span>
-					<input type="text" name="<?php echo htmlspecialchars($GLOBALS['_config']['url_var_name']) ?>" value="<?php echo isset($_GET[$GLOBALS['_config']['url_var_name']]) ? htmlspecialchars(decode_url($_GET[$GLOBALS['_config']['url_var_name']])) : (isset($_GET['__iv']) ? htmlspecialchars($_GET['__iv']) : ''); ?>" placeholder="http://www.example.com/index.html?ref=PHProxy" required="required"/>
-				</label>
-			</div>
-			<div class="form-row">
-				<button class="button-submit" type="submit">Proxify</button>
-				<label class="button-cancel" for="proxopttogl">Options</label>
-			</div>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <title><?php echo htmlspecialchars($GLOBALS['_config']['site_name']); ?></title>
+    <link rel="stylesheet" href="./files/css/index.css"/>
+    <script src="./files/js/index.js"></script>
+</head>
+<body>
+<?php if ($data['category'] != 'auth'): ?>
+<form method="post" action="<?php echo htmlspecialchars($_SERVER['PHP_SELF']); ?>">
+    <div class="main">
+        <div class="form-title-row">
+            <h1><?php echo htmlspecialchars($GLOBALS['_config']['site_name']); ?></h1>
+        </div>
+        <div class="form-row">
+            <label>
+                <span>Enter full URL:</span>
+                <input type="text" name="<?php echo htmlspecialchars($GLOBALS['_config']['url_var_name']) ?>" value="<?php echo isset($_GET[$GLOBALS['_config']['url_var_name']]) ? htmlspecialchars(decode_url($_GET[$GLOBALS['_config']['url_var_name']])) : (isset($_GET['__iv']) ? htmlspecialchars($_GET['__iv']) : ''); ?>" placeholder="https://www.example.com/" required="required" autocomplete="off" autofocus/>
+            </label>
+        </div>
+        <div class="form-row">
+            <button class="button-submit" type="submit">Proxify</button>
+            <label class="button-cancel" for="proxopttogl">Options</label>
+        </div>
 <?php
 switch ($data['category']) {
     case 'error':
@@ -287,58 +75,58 @@ switch ($data['category']) {
         break;
 }
 ?>
-		</div>
-		<?php if (in_array(0, $GLOBALS['_frozen_flags'])): ?>
-<input type="checkbox" id="proxopttogl"/>
-		<div id="proxoptmenu" class="main">
-			<div class="form-title-row">
-				<h1>Options</h1>
-			</div>
-			<div class="prx-opt-menu">
-				<li id="newWin" class="option" style="display: none;"><label><input type="checkbox"/>Open URL in a new window</label></li>
+    </div>
+    <?php if (in_array(0, $GLOBALS['_frozen_flags'])): ?>
+    <input type="checkbox" id="proxopttogl"/>
+    <div id="proxoptmenu" class="main">
+        <div class="form-title-row">
+            <h1>Options</h1>
+        </div>
+        <ul class="prx-opt-menu">
+            <li id="newWin" class="option" style="display: none;"><label><input type="checkbox"/>Open URL in a new window</label></li>
 <?php
 foreach ($GLOBALS['_flags'] as $flag_name => $flag_value) {
     if (!$GLOBALS['_frozen_flags'][$flag_name]) {
-        echo '<li class="option"><label><input type="checkbox" name="' . $GLOBALS['_config']['flags_var_name'] . '[' . $flag_name . ']"' . ($flag_value ? ' checked="checked"' : '') . ' />' . htmlspecialchars($GLOBALS['_labels'][$flag_name][1]) . '</label></li>' . "\n";
+        echo '            <li class="option"><label><input type="checkbox" name="' . $GLOBALS['_config']['flags_var_name'] . '[' . $flag_name . ']"' . ($flag_value ? ' checked="checked"' : '') . ' />' . htmlspecialchars($GLOBALS['_labels'][$flag_name][1]) . '</label></li>' . "\n";
     }
 }
 ?>
-				</div>
-				<a href="edit.php">MORE...</a>
-			</div>
-		<?php endif;?>
+        </ul>
+        <a class="more-link" href="edit.php">More settings &rarr;</a>
+    </div>
+    <?php endif; ?>
 </form>
-		<?php elseif ($data['category'] == 'auth'): ?>
-
-			<form class="auth" method="post" action="<?php echo htmlspecialchars($_SERVER['REQUEST_URI']); ?>">
-		<div class="main main-auth-box">
-			<div class="form-title-row">
-				<h1 class="auth-header">Authentication Required</h1>
-			</div>
-				<input type="hidden" name="<?php echo htmlspecialchars($GLOBALS['_config']['basic_auth_var_name']) ?>" value="<?php echo base64_encode($data['realm']) ?>" />
-				<div class="form-row">
-					<label>
-						<span>Enter username:</span>
-						<input type="username" name="username" placeholder="Username">
-					</label>
-					<label>
-						<span>Enter password:</span>
-						<input type="password" name="password" placeholder="Password">
-					</label>
-				</div>
-
-				<div class="form-row">
-					<button class="button-submit" type="submit">Login</button>
-					<a class="button-cancel" href="index.php<?php echo '?__iv=' . rawurlencode($GLOBALS['_url']); ?>">Cancel</a>
-				</div>
-			<?php if (!empty($_POST['username']) || !empty($_POST['password'])): ?>
-				<p class="error"><b>Authentication Required: </b>The supplied credentials were unauthorized to access the specified content.</p>
-			<?php else: ?>
-				<p class="info"><b>Authentication Required: </b>Enter your username and password for "<?php echo htmlspecialchars($data['realm']); ?>" on <?php echo htmlspecialchars($GLOBALS['_url_parts']['host']); ?></p>
-			<?php endif;?>
-		</div>
+<?php elseif ($data['category'] == 'auth'): ?>
+<form class="auth" method="post" action="<?php echo htmlspecialchars($_SERVER['REQUEST_URI']); ?>">
+    <div class="main main-auth-box">
+        <div class="form-title-row">
+            <h1 class="auth-header">Authentication Required</h1>
+        </div>
+        <input type="hidden" name="<?php echo htmlspecialchars($GLOBALS['_config']['basic_auth_var_name']) ?>" value="<?php echo base64_encode($data['realm']) ?>"/>
+        <div class="form-row">
+            <label>
+                <span>Username</span>
+                <input type="text" name="username" placeholder="Username" autocomplete="username"/>
+            </label>
+        </div>
+        <div class="form-row">
+            <label>
+                <span>Password</span>
+                <input type="password" name="password" placeholder="Password" autocomplete="current-password"/>
+            </label>
+        </div>
+        <div class="form-row">
+            <button class="button-submit" type="submit">Login</button>
+            <a class="button-cancel" href="index.php<?php echo '?__iv=' . rawurlencode($GLOBALS['_url']); ?>">Cancel</a>
+        </div>
+        <?php if (!empty($_POST['username']) || !empty($_POST['password'])): ?>
+        <p class="error"><b>Authentication Required: </b>The supplied credentials were unauthorized to access the specified content.</p>
+        <?php else: ?>
+        <p class="info"><b>Authentication Required: </b>Enter your username and password for &quot;<?php echo htmlspecialchars($data['realm']); ?>&quot; on <?php echo htmlspecialchars($GLOBALS['_url_parts']['host']); ?></p>
+        <?php endif; ?>
+    </div>
 </form>
-<?php endif;?>
-<center><small><a href="https://github.com/PHProxy/phproxy" style="text-decoration: none;">PHProxy</a> <?=$GLOBALS['_version'];?></small></center>
-	</body>
+<?php endif; ?>
+<p class="footer"><a href="https://github.com/PHProxy/phproxy">PHProxy</a> <?= $GLOBALS['_version']; ?></p>
+</body>
 </html>

--- a/files/php/index.inc.php
+++ b/files/php/index.inc.php
@@ -2,6 +2,17 @@
 if (basename(__FILE__) == basename($_SERVER['PHP_SELF'])) {
     exit(0);
 }
+
+// Cookies the proxy itself owns (settings), excluded from the user-facing list
+$_proxy_settings_cookies = ['flags', 'userAgent', 'PHPSESSID'];
+$_visible_cookies = [];
+foreach ($_COOKIE as $_k => $_v) {
+    if (!in_array($_k, $_proxy_settings_cookies, true)) {
+        $_visible_cookies[$_k] = $_v;
+    }
+}
+
+$_current_ua = isset($_COOKIE['userAgent']) ? $_COOKIE['userAgent'] : '';
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -10,29 +21,42 @@ if (basename(__FILE__) == basename($_SERVER['PHP_SELF'])) {
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title><?php echo htmlspecialchars($GLOBALS['_config']['site_name']); ?></title>
     <link rel="stylesheet" href="./files/css/index.css"/>
-    <script src="./files/js/index.js"></script>
+    <script>
+    (function () {
+        var s = null;
+        try { s = localStorage.getItem('phproxy-theme'); } catch (e) {}
+        if (s === 'dark' || s === 'light') {
+            document.documentElement.setAttribute('data-theme', s);
+        }
+    })();
+    </script>
 </head>
 <body>
+<div class="page">
+    <header class="appbar">
+        <h1><?php echo htmlspecialchars($GLOBALS['_config']['site_name']); ?><span class="dot">.</span></h1>
+        <button type="button" class="theme-toggle" aria-label="Toggle colour theme" title="Toggle colour theme">
+            <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <circle cx="12" cy="12" r="4"/>
+                <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/>
+            </svg>
+            <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+            </svg>
+        </button>
+    </header>
+
 <?php if ($data['category'] != 'auth'): ?>
-<form method="post" action="<?php echo htmlspecialchars($_SERVER['PHP_SELF']); ?>">
-    <div class="main">
-        <div class="form-title-row">
-            <h1><?php echo htmlspecialchars($GLOBALS['_config']['site_name']); ?></h1>
-        </div>
-        <div class="form-row">
-            <label>
-                <span>Enter full URL:</span>
-                <input type="text" name="<?php echo htmlspecialchars($GLOBALS['_config']['url_var_name']) ?>" value="<?php echo isset($_GET[$GLOBALS['_config']['url_var_name']]) ? htmlspecialchars(decode_url($_GET[$GLOBALS['_config']['url_var_name']])) : (isset($_GET['__iv']) ? htmlspecialchars($_GET['__iv']) : ''); ?>" placeholder="https://www.example.com/" required="required" autocomplete="off" autofocus/>
-            </label>
-        </div>
-        <div class="form-row">
-            <button class="button-submit" type="submit">Proxify</button>
-            <label class="button-cancel" for="proxopttogl">Options</label>
-        </div>
+    <form method="post" action="<?php echo htmlspecialchars($_SERVER['PHP_SELF']); ?>">
+        <div class="card">
+            <div class="form-row url-row">
+                <input class="url-input" type="text" name="<?php echo htmlspecialchars($GLOBALS['_config']['url_var_name']) ?>" value="<?php echo isset($_GET[$GLOBALS['_config']['url_var_name']]) ? htmlspecialchars(decode_url($_GET[$GLOBALS['_config']['url_var_name']])) : (isset($_GET['__iv']) ? htmlspecialchars($_GET['__iv']) : ''); ?>" placeholder="https://www.example.com/" required autofocus autocomplete="off"/>
+                <button class="button-submit" type="submit">Proxify</button>
+            </div>
 <?php
 switch ($data['category']) {
     case 'error':
-        echo '<p class="error">';
+        echo '            <p class="error">';
 
         switch ($data['group']) {
             case 'url':
@@ -59,74 +83,141 @@ switch ($data['category']) {
                 echo '<b>Resource Error:</b> ';
                 switch ($data['type']) {
                     case 'file_size':
-                        $message = 'The file your are attempting to download is too large.<br />'
-                        . 'Maxiumum permissible file size is <b>' . number_format($GLOBALS['_config']['max_file_size'] / 1048576, 2) . ' MB</b><br />'
+                        $message = 'The file your are attempting to download is too large.<br/>'
+                        . 'Maxiumum permissible file size is <b>' . number_format($GLOBALS['_config']['max_file_size'] / 1048576, 2) . ' MB</b><br/>'
                         . 'Requested file size is <b>' . number_format($GLOBALS['_content_length'] / 1048576, 2) . ' MB</b>';
                         break;
                     case 'hotlinking':
-                        $message = 'It appears that you are trying to access a resource through this proxy from a remote Website.<br />'
+                        $message = 'It appears that you are trying to access a resource through this proxy from a remote Website.<br/>'
                             . 'For security reasons, please use the form below to do so.';
                         break;
                 }
                 break;
         }
 
-        echo 'An error has occured while trying to browse through the proxy. <br />' . $message . '</p>';
+        echo 'An error has occured while trying to browse through the proxy. <br/>' . $message . '</p>';
         break;
 }
 ?>
-    </div>
-    <?php if (in_array(0, $GLOBALS['_frozen_flags'])): ?>
-    <input type="checkbox" id="proxopttogl"/>
-    <div id="proxoptmenu" class="main">
-        <div class="form-title-row">
-            <h1>Options</h1>
         </div>
-        <ul class="prx-opt-menu">
-            <li id="newWin" class="option" style="display: none;"><label><input type="checkbox"/>Open URL in a new window</label></li>
+
+        <?php if (in_array(0, $GLOBALS['_frozen_flags'])): ?>
+        <div class="card">
+            <div class="tabs-wrap">
+                <input type="radio" name="tab" id="tab-options" checked/>
+                <input type="radio" name="tab" id="tab-cookies"/>
+                <input type="radio" name="tab" id="tab-headers"/>
+
+                <nav class="tabs">
+                    <label for="tab-options">Options</label>
+                    <label for="tab-cookies">Cookies</label>
+                    <label for="tab-headers">Headers</label>
+                </nav>
+
+                <section class="tab-panel" data-tab="options">
+                    <ul class="prx-opt-menu">
 <?php
 foreach ($GLOBALS['_flags'] as $flag_name => $flag_value) {
     if (!$GLOBALS['_frozen_flags'][$flag_name]) {
-        echo '            <li class="option"><label><input type="checkbox" name="' . $GLOBALS['_config']['flags_var_name'] . '[' . $flag_name . ']"' . ($flag_value ? ' checked="checked"' : '') . ' />' . htmlspecialchars($GLOBALS['_labels'][$flag_name][1]) . '</label></li>' . "\n";
+        echo '                        <li class="option"><label><input type="checkbox" name="' . $GLOBALS['_config']['flags_var_name'] . '[' . $flag_name . ']"' . ($flag_value ? ' checked="checked"' : '') . '/>' . htmlspecialchars($GLOBALS['_labels'][$flag_name][1]) . '</label></li>' . "\n";
     }
 }
 ?>
-        </ul>
-        <a class="more-link" href="edit.php">More settings &rarr;</a>
-    </div>
-    <?php endif; ?>
-</form>
-<?php elseif ($data['category'] == 'auth'): ?>
-<form class="auth" method="post" action="<?php echo htmlspecialchars($_SERVER['REQUEST_URI']); ?>">
-    <div class="main main-auth-box">
-        <div class="form-title-row">
-            <h1 class="auth-header">Authentication Required</h1>
-        </div>
-        <input type="hidden" name="<?php echo htmlspecialchars($GLOBALS['_config']['basic_auth_var_name']) ?>" value="<?php echo base64_encode($data['realm']) ?>"/>
-        <div class="form-row">
-            <label>
-                <span>Username</span>
-                <input type="text" name="username" placeholder="Username" autocomplete="username"/>
-            </label>
-        </div>
-        <div class="form-row">
-            <label>
-                <span>Password</span>
-                <input type="password" name="password" placeholder="Password" autocomplete="current-password"/>
-            </label>
-        </div>
-        <div class="form-row">
-            <button class="button-submit" type="submit">Login</button>
-            <a class="button-cancel" href="index.php<?php echo '?__iv=' . rawurlencode($GLOBALS['_url']); ?>">Cancel</a>
-        </div>
-        <?php if (!empty($_POST['username']) || !empty($_POST['password'])): ?>
-        <p class="error"><b>Authentication Required: </b>The supplied credentials were unauthorized to access the specified content.</p>
-        <?php else: ?>
-        <p class="info"><b>Authentication Required: </b>Enter your username and password for &quot;<?php echo htmlspecialchars($data['realm']); ?>&quot; on <?php echo htmlspecialchars($GLOBALS['_url_parts']['host']); ?></p>
-        <?php endif; ?>
-    </div>
-</form>
+                    </ul>
+                </section>
+
+                <section class="tab-panel" data-tab="cookies">
+<?php if (empty($_visible_cookies)): ?>
+                    <p class="tab-help">No proxied cookies stored.</p>
+                    <ul class="cookie-list"><li class="empty">Nothing here yet</li></ul>
+<?php else: ?>
+                    <p class="tab-help"><?php echo count($_visible_cookies); ?> cookie<?php echo count($_visible_cookies) === 1 ? '' : 's'; ?> held for proxied sites.</p>
+                    <ul class="cookie-list">
+<?php foreach ($_visible_cookies as $_name => $_value): ?>
+                        <li><span><?php echo htmlspecialchars($_name); ?></span></li>
+<?php endforeach; ?>
+                    </ul>
 <?php endif; ?>
-<p class="footer"><a href="https://github.com/PHProxy/phproxy">PHProxy</a> <?= $GLOBALS['_version']; ?></p>
+                    <div class="tab-actions">
+                        <button class="button-ghost" type="submit" formaction="?action=clear-cookies" formmethod="post" formnovalidate>Clear all cookies</button>
+                    </div>
+                </section>
+
+                <section class="tab-panel" data-tab="headers">
+                    <p class="tab-help">Outgoing request headers sent on your behalf. Empty means "use browser default", <code>.</code> means "use my real browser User-Agent", <code>-</code> means "send no User-Agent".</p>
+                    <div class="form-row">
+                        <label>
+                            <span>User-Agent</span>
+                            <input type="text" name="userAgent" list="user-agents" value="<?php echo htmlspecialchars($_current_ua); ?>" placeholder="Default browser User-Agent" autocomplete="off"/>
+                            <datalist id="user-agents">
+                                <option value="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36" label="Chrome on Windows"/>
+                                <option value="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15" label="Safari on macOS"/>
+                                <option value="Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1" label="Safari on iPhone"/>
+                                <option value="Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Mobile Safari/537.36" label="Chrome on Android"/>
+                                <option value="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36" label="Chrome on Linux"/>
+                                <option value="." label="Use my real browser User-Agent"/>
+                                <option value="-" label="Send no User-Agent at all"/>
+                            </datalist>
+                        </label>
+                    </div>
+                    <div class="tab-actions">
+                        <button class="button-cancel" type="submit" formaction="edit.php" formmethod="post" formnovalidate name="action" value="submit">Save headers</button>
+                    </div>
+                </section>
+            </div>
+        </div>
+        <?php endif; ?>
+    </form>
+<?php elseif ($data['category'] == 'auth'): ?>
+    <form class="auth" method="post" action="<?php echo htmlspecialchars($_SERVER['REQUEST_URI']); ?>">
+        <div class="card main-auth-box">
+            <div class="form-title-row">
+                <h2 class="auth-header">Authentication Required</h2>
+            </div>
+            <input type="hidden" name="<?php echo htmlspecialchars($GLOBALS['_config']['basic_auth_var_name']) ?>" value="<?php echo base64_encode($data['realm']) ?>"/>
+            <div class="form-row">
+                <label>
+                    <span>Username</span>
+                    <input type="text" name="username" placeholder="Username" autocomplete="username"/>
+                </label>
+            </div>
+            <div class="form-row">
+                <label>
+                    <span>Password</span>
+                    <input type="password" name="password" placeholder="Password" autocomplete="current-password"/>
+                </label>
+            </div>
+            <div class="tab-actions">
+                <button class="button-submit" type="submit">Login</button>
+                <a class="button-cancel" href="index.php<?php echo '?__iv=' . rawurlencode($GLOBALS['_url']); ?>">Cancel</a>
+            </div>
+            <?php if (!empty($_POST['username']) || !empty($_POST['password'])): ?>
+            <p class="error"><b>Authentication Required: </b>The supplied credentials were unauthorized to access the specified content.</p>
+            <?php else: ?>
+            <p class="info"><b>Authentication Required: </b>Enter your username and password for &quot;<?php echo htmlspecialchars($data['realm']); ?>&quot; on <?php echo htmlspecialchars($GLOBALS['_url_parts']['host']); ?></p>
+            <?php endif; ?>
+        </div>
+    </form>
+<?php endif; ?>
+
+    <p class="footer"><a href="https://github.com/PHProxy/phproxy">PHProxy</a> <?= $GLOBALS['_version']; ?></p>
+</div>
+
+<script>
+(function () {
+    var root = document.documentElement;
+    var btn = document.querySelector('.theme-toggle');
+    if (!btn) return;
+    btn.addEventListener('click', function () {
+        var cur = root.getAttribute('data-theme');
+        if (!cur) {
+            cur = matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        var next = cur === 'dark' ? 'light' : 'dark';
+        root.setAttribute('data-theme', next);
+        try { localStorage.setItem('phproxy-theme', next); } catch (e) {}
+    });
+})();
+</script>
 </body>
 </html>

--- a/index.php
+++ b/index.php
@@ -153,6 +153,24 @@ $_bindip           = 'default';
 require_once "./files/php/functions.inc.php";
 
 //
+// CLEAR COOKIES action (from the Cookies tab)
+// Expires every non-settings cookie under the proxy's own domain and bounces
+// back to the entry form.
+//
+if (isset($_GET['action']) && $_GET['action'] === 'clear-cookies' && $_SERVER['REQUEST_METHOD'] === 'POST')
+{
+    $_settings = ['flags', 'userAgent', 'PHPSESSID'];
+    foreach ($_COOKIE as $_ck_name => $_ck_value)
+    {
+        if (in_array($_ck_name, $_settings, true)) continue;
+        setcookie($_ck_name, '', time() - 3600, '/');
+        setcookie($_ck_name, '', time() - 3600, '/', '.' . $_http_host);
+    }
+    header('Location: ' . $_script_url);
+    exit(0);
+}
+
+//
 // SET FLAGS
 //
 

--- a/index.php
+++ b/index.php
@@ -1096,22 +1096,31 @@ else
     require_once "./files/php/misc.override.php";
     if ($_flags['include_form'] && !isset($_GET['nf']))
     {
-        $_url_form      = '<div style="width:100%;margin:0;text-align:center;border-bottom:1px solid #725554;color:#000000;background-color:#F2FDF3;font-size:12px;font-weight:bold;font-family:Bitstream Vera Sans,arial,sans-serif;padding:4px;">'
-                        . '<form method="post" action="' . $_script_url . '">'
-                        . ' <label for="____' . $_config['url_var_name'] . '"><a href="' . $_url . '">Address</a>:</label> <input id="____' . $_config['url_var_name'] . '" type="text" size="80" name="' . $_config['url_var_name'] . '" value="' . $_url . '" />'
-                        . ' <input type="submit" name="go" value="Go" />'
-                        . ' [go: <a href="' . $_script_url . '?' . $_config['url_var_name'] . '=' . encode_url($_url_parts['prev_dir']) .' ">up one dir</a>, <a href="' . $_script_base . '">main page</a>]'
-                        . '<br /><hr />';
+        // PHProxy mini URL bar injected into proxied pages.
+        // Uses scoped inline styles so it survives the target page's CSS.
+        $_bar_style = "all:initial;display:block;position:relative;z-index:2147483647;box-sizing:border-box;width:100%;margin:0;padding:8px 12px;background:#0f172a;color:#f1f5f9;font:13px/1.4 -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;border-bottom:1px solid #334155;";
+        $_bar_input = 'box-sizing:border-box;flex:1 1 320px;min-width:0;padding:6px 10px;background:#1e293b;color:#f1f5f9;border:1px solid #334155;border-radius:6px;font:inherit;';
+        $_bar_btn   = 'padding:6px 14px;background:#3b82f6;color:#fff;border:0;border-radius:6px;font:600 13px inherit;cursor:pointer;text-decoration:none;';
+        $_bar_link  = 'color:#93c5fd;text-decoration:none;margin-left:8px;';
+        $_bar_chk   = 'color:#cbd5e1;font:13px inherit;display:inline-flex;align-items:center;gap:4px;margin-right:12px;';
 
+        $_url_form  = '<div style="' . $_bar_style . '">'
+                    . '<form method="post" action="' . $_script_url . '" style="all:initial;display:flex;flex-wrap:wrap;gap:8px;align-items:center;font:inherit;color:inherit;">'
+                    . '<input id="____' . $_config['url_var_name'] . '" type="text" name="' . $_config['url_var_name'] . '" value="' . $_url . '" style="' . $_bar_input . '"/>'
+                    . '<button type="submit" name="go" style="' . $_bar_btn . '">Go</button>'
+                    . '<a href="' . $_script_url . '?' . $_config['url_var_name'] . '=' . encode_url($_url_parts['prev_dir']) . '" style="' . $_bar_link . '">Up</a>'
+                    . '<a href="' . $_script_base . '" style="' . $_bar_link . '">Home</a>'
+                    . '</form>';
+
+        $_url_form .= '<div style="margin-top:6px;display:flex;flex-wrap:wrap;align-items:center;">';
         foreach ($_flags as $flag_name => $flag_value)
         {
             if (!$_frozen_flags[$flag_name])
             {
-                $_url_form .= '<label><input type="checkbox" name="' . $_config['flags_var_name'] . '[' . $flag_name . ']"' . ($flag_value ? ' checked="checked"' : '') . ' /> ' . $_labels[$flag_name][0] . '</label> ';
+                $_url_form .= '<label style="' . $_bar_chk . '"><input type="checkbox" name="' . $_config['flags_var_name'] . '[' . $flag_name . ']"' . ($flag_value ? ' checked="checked"' : '') . ' style="margin:0;accent-color:#3b82f6;"/> ' . $_labels[$flag_name][0] . '</label>';
             }
         }
-
-        $_url_form .= '</form></div>';
+        $_url_form .= '</div></div>';
         $_response_body = preg_replace('#\<\s*body(.*?)\>#si', "$0\n$_url_form" , $_response_body, 1);
     }
 }


### PR DESCRIPTION
## Summary

Visual refresh of the entry, settings, error, and auth views, plus a tabbed control panel and a manual theme toggle.

Closes the spirit of the user's own long-standing wish [#4 (Better interface)](https://github.com/PHProxy/phproxy/issues/4).

Independent of [#49](https://github.com/PHProxy/phproxy/pull/49) — disjoint files.

## Layout

```
PHProxy.                          [☀/🌙 SVG]    <- app bar
┌──────────────────────────────────────────┐
│ [ https://www.example.com/  ] [Proxify ] │    <- URL card, autofocused
└──────────────────────────────────────────┘
┌──────────────────────────────────────────┐
│  Options   Cookies   Headers             │    <- CSS-only tabs
│  ─────────                                │
│  ☐ Include Form   ☐ Remove Scripts ...    │    <- Options is the default
└──────────────────────────────────────────┘
                PHProxy v1.1.1
```

## What changed

### `files/css/index.css` — single source of truth
- CSS custom properties for palette, two surfaces, mono font stack
- Automatic dark mode via `prefers-color-scheme: dark`, overridable via `[data-theme="dark"]` / `[data-theme="light"]` on `<html>` (toggle wins, otherwise system pref)
- Mobile-first responsive (options grid collapses to 1-col under 600px)
- Accessible focus rings (3px accent halo on inputs)
- `accent-color` on checkboxes
- Tabs styling (active tab gets accent-color underline)
- Cookie list with mono font + dashed empty state

### `files/php/index.inc.php` — entry / error / auth template
- XHTML 1.0 → HTML5
- New app bar with logo + theme toggle button (two inline SVGs, currentColor stroke)
- Three tabs: **Options** (default), **Cookies**, **Headers**
  - Options: existing flag checkboxes (now in a 2-col grid)
  - Cookies: enumerates non-settings `$_COOKIE` entries the proxy is holding for proxied sites, with a **Clear all cookies** action that POSTs `?action=clear-cookies` and redirects back. Settings cookies (`flags`, `userAgent`, `PHPSESSID`) are preserved.
  - Headers: User-Agent picker (tidied UA list with current Chrome/Safari/iOS/Android). Save button uses `formaction="edit.php"` so the existing `edit.php` handler keeps working
- URL field keeps `autofocus` and `autocomplete="off"`
- Username/password fields get correct `autocomplete` tokens
- Deprecated `<center>` dropped (replaced by styled `.footer`)

### `index.php` — clear-cookies handler
Right after `functions.inc.php` is loaded, a small handler responds to `POST /?action=clear-cookies`. It iterates `$_COOKIE`, sends an expired `Set-Cookie` for each non-settings entry (under both `/` and `.$HTTP_HOST` to clean up under either domain scope), then redirects to the entry form.

### `index.php` — `include_form` mini URL bar (still in this PR)
Restyled as a scoped dark slate bar with `all:initial`, `z-index:2147483647`, flexbox URL field + Go button, clean inline checkboxes. Self-contained inline styles only.

### Theme toggle (new)
- 36x36 button in the app bar, ghost styling
- Inline JavaScript:
  - Early `<script>` in `<head>` reads `localStorage['phproxy-theme']` and sets `data-theme` **before paint** — no flash of wrong theme on reload
  - Click flips light ⇄ dark and persists in `localStorage`
  - Wrapped in `try/catch` so private-mode browsers without storage still work

## Test plan

Verified inside `php:8.5-apache` (PHP 8.5.6):

- [x] `php -l` clean on every `*.php`
- [x] Entry form: HTML5 doctype, linked CSS, URL field autofocused
- [x] Theme toggle button present with both SVG icons; `data-theme` flip + localStorage persistence verified
- [x] Tabs switch via CSS only (no JS needed for the tabs themselves); Options is the default
- [x] Cookies tab: list renders, empty state renders when no proxy cookies exist
- [x] Clear-cookies action returns 302 + emits expired `Set-Cookie` for non-settings cookies only (verified `flags`, `userAgent`, `PHPSESSID` are preserved)
- [x] Headers tab: Save button posts to `edit.php` which still works
- [x] Auth page: same look, warning-coloured header to differentiate
- [x] Error page: renders inside the new `.card` + `p.error` styles
- [x] `edit.php` still works standalone for backward compatibility (HTTP 200)
- [x] Proxied page with `include_form` flag on: restyled scoped mini bar injects correctly
- [x] Dev-mode `error_reporting(E_ALL) + display_errors=1`: zero deprecations / warnings / notices

Preview at `http://localhost:8080/` if the dev container is up. Switch your OS dark mode or click the toggle to test theming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)